### PR TITLE
android: Fix services NPE crash

### DIFF
--- a/android/.idea/deviceManager.xml
+++ b/android/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/android/app/src/main/java/com/nizarmah/igatha/service/DisasterDetectionService.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/service/DisasterDetectionService.kt
@@ -12,13 +12,15 @@ class DisasterDetectionService : Service() {
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
-    private val emergencyManager = EmergencyManager.getInstance(this)
+    private lateinit var emergencyManager: EmergencyManager
 
     private var confirmationJob: Job? = null
 
     override fun onCreate() {
         super.onCreate()
 
+        // Initialize inside onCreate because context is not available earlier
+        emergencyManager = EmergencyManager.getInstance(applicationContext)
         emergencyManager.startDetector()
 
         // Start the service in the foreground with a low-priority notification

--- a/android/app/src/main/java/com/nizarmah/igatha/service/EmergencyManager.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/service/EmergencyManager.kt
@@ -17,9 +17,12 @@ class EmergencyManager private constructor(context: Context) {
         @Volatile
         private var instance: EmergencyManager? = null
 
-        fun getInstance(context: Context): EmergencyManager {
+        fun getInstance(ctx: Context?): EmergencyManager {
+            val appCtx = ctx?.applicationContext
+                ?: throw IllegalStateException("EmergencyManager requested with null Context")
+
             return instance ?: synchronized(this) {
-                instance ?: EmergencyManager(context.applicationContext).also { instance = it }
+                instance ?: EmergencyManager(appCtx).also { instance = it }
             }
         }
     }

--- a/android/app/src/main/java/com/nizarmah/igatha/service/SOSService.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/service/SOSService.kt
@@ -12,10 +12,13 @@ class SOSService : Service() {
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
-    private val emergencyManager = EmergencyManager.getInstance(this)
+    private lateinit var emergencyManager: EmergencyManager
 
     override fun onCreate() {
         super.onCreate()
+
+        // Initialize inside onCreate because context is not available earlier
+        emergencyManager = EmergencyManager.getInstance(applicationContext)
 
         startSOS()
     }


### PR DESCRIPTION
Resolves #10 

Before:
1. Services initialized EmergencyManager before app context existed

After:
1. Services initialize EmergencyManager after app context exists
2. Hardened EmergencyManager to avoid NPE

Test:
1. I tried reproducing this with SDK 34 and 33 (affected), but no luck.