### PR TITLE
ios: Add feedback reminder notif

### DIFF
--- a/ios/Igatha/AppDelegate.swift
+++ b/ios/Igatha/AppDelegate.swift
@@ -6,18 +6,50 @@
 //
 
 import SwiftUI
+import UserNotifications
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var emergencyManager: EmergencyManager!
-    
+    var notificationManager: NotificationManager!
+    var deepLinkHandler: DeepLinkHandler!
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions:
         [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        // initialize EmergencyManager
+        // Initialize emergency manager
         emergencyManager = EmergencyManager.shared
-        
+
+        // Initialize notification manager and request authorization
+        notificationManager = NotificationManager.shared
+        notificationManager.setup()
+
+        // Initialize deep link handler
+        deepLinkHandler = DeepLinkHandler.shared
+
         return true
+    }
+
+    // Handle deep links when app is launched via URL
+    func application(
+        _ app: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey : Any] = [:]
+    ) -> Bool {
+        return deepLinkHandler.handleDeepLink(url)
+    }
+
+    // Handle deep links in universal links format
+    func application(
+        _ application: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
+        if userActivity.activityType == NSUserActivityTypeBrowsingWeb, let url = userActivity.webpageURL {
+            return deepLinkHandler.handleDeepLink(url)
+        }
+
+        return false
     }
 }

--- a/ios/Igatha/AppDelegate.swift
+++ b/ios/Igatha/AppDelegate.swift
@@ -19,9 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         // Initialize managers in the background
-        Task {
-            await setupManagers()
-        }
+        Task { await setupManagers() }
 
         return true
     }

--- a/ios/Igatha/AppDelegate.swift
+++ b/ios/Igatha/AppDelegate.swift
@@ -18,17 +18,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions:
         [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        // Initialize managers in the background
+        Task {
+            await setupManagers()
+        }
+
+        return true
+    }
+
+    private func setupManagers() async {
+        // Initialize notification manager first since it needs to be set as delegate
+        notificationManager = NotificationManager.shared
+
         // Initialize emergency manager
         emergencyManager = EmergencyManager.shared
-
-        // Initialize notification manager and request authorization
-        notificationManager = NotificationManager.shared
-        notificationManager.setup()
 
         // Initialize deep link handler
         deepLinkHandler = DeepLinkHandler.shared
 
-        return true
+        // Set up notification manager (will request permissions and schedule notifications)
+        await notificationManager.setup()
     }
 
     // Handle deep links when app is launched via URL

--- a/ios/Igatha/Constants.swift
+++ b/ios/Igatha/Constants.swift
@@ -32,4 +32,35 @@ struct Constants {
 
     // percentage of how much a new value should affect the old value
     static let RSSIExponentialMovingAverageSmoothingFactor: Double = 0.18
+
+    // Deep links.
+    struct DeepLink {
+        // Properties.
+        static let Key: String = "deepLink"
+        static let Scheme: String = "igatha"
+
+        // Actions.
+        struct Settings {
+            static let Name: String = "OpenSettings"
+            static let Value: String = "settings"
+        }
+    }
+
+    // Notification identifiers
+    struct Notifications {
+        struct Feedback {
+            static let Id: String = "feedbackRequest"
+
+            // We open Settings instead of FeedbackForm because it's easier
+            // Chaining NavigationLink(isActive) is a bit difficult, when nested
+            // Once we start using iOS 16+, we'll be able to open the form directly
+            static let Link = DeepLink.Settings.self
+
+            // Delay before the notification is shown (in seconds)
+            static let TriggerDelay: TimeInterval = 3 * 24 * 60 * 60
+
+            // Key for the timestamp of the feedback request notification
+            static let TimestampKey: String = "feedbackScheduledTimestamp"
+        }
+    }
 }

--- a/ios/Igatha/Info.plist
+++ b/ios/Igatha/Info.plist
@@ -27,6 +27,23 @@
             <string>audio</string>
             <!-- Used by disaster detector -->
             <string>location</string>
+            <!-- Used for scheduled notifications -->
+            <string>remote-notification</string>
+        </array>
+
+        <!-- URL Scheme for Deep Links -->
+        <key>CFBundleURLTypes</key>
+        <array>
+            <dict>
+                <key>CFBundleTypeRole</key>
+                <string>Editor</string>
+                <key>CFBundleURLName</key>
+                <string>com.nizarmah.igatha</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>igatha</string>
+                </array>
+            </dict>
         </array>
 
         <!-- Compliance -->

--- a/ios/Igatha/Services/DeepLinkHandler.swift
+++ b/ios/Igatha/Services/DeepLinkHandler.swift
@@ -1,0 +1,52 @@
+//
+//  DeepLinkHandler.swift
+//  Igatha
+//
+//  Created by Nizar Mahmoud on 22/04/2025.
+//
+
+import Foundation
+import SwiftUI
+
+class DeepLinkHandler: ObservableObject {
+    static let shared = DeepLinkHandler()
+
+    @Published var showSettings = false
+
+    private init() {
+        // Listen for deep link events
+
+        registerSettingsObserver()
+    }
+
+    // registerSettingsObserver listens for settings deep link notification events
+    private func registerSettingsObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleSettings),
+            name: NSNotification.Name(Constants.DeepLink.Settings.Name),
+            object: nil
+        )
+    }
+
+    // handleSettings opens the settings view
+    @objc @MainActor private func handleSettings() {
+        showSettings = true
+    }
+
+    // handleDeepLink is called from the outside to handle a deep link
+    @MainActor func handleDeepLink(_ url: URL) -> Bool {
+        // Check if the URL scheme is igatha
+        guard let scheme = url.scheme, scheme == Constants.DeepLink.Scheme else {
+            return false
+        }
+
+        // Check if the host is feedback
+        if url.host == Constants.DeepLink.Settings.Value {
+            handleSettings()
+            return true
+        }
+
+        return false
+    }
+}

--- a/ios/Igatha/Services/NotificationManager.swift
+++ b/ios/Igatha/Services/NotificationManager.swift
@@ -13,14 +13,12 @@ class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
     static let shared = NotificationManager()
 
     // setup is called when the app is launched
-    public func setup() {
-        // Request authorization and schedule notification using Task
-        Task {
-            let granted = await requestAuthorization()
-            guard granted else { return }
-
-            // Schedule feedback request notification when permission is granted
+    func setup() async {
+        do {
+            try await requestAuthorization()
             await scheduleFeedbackRequestNotification()
+        } catch {
+            NSLog("Error setting up notification manager: \(error)")
         }
     }
 
@@ -32,10 +30,9 @@ class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
     }
 
     // requestAuthorization requests notification permission
-    private func requestAuthorization() async -> Bool {
-        return (try? await UNUserNotificationCenter.current().requestAuthorization(
-            options: [.alert, .sound, .badge]
-        )) ?? false
+    private func requestAuthorization() async throws {
+        let options: UNAuthorizationOptions = [.alert, .sound, .badge]
+        try await UNUserNotificationCenter.current().requestAuthorization(options: options)
     }
 
     // scheduleFeedbackRequestNotification schedules the feedback request notification

--- a/ios/Igatha/Services/NotificationManager.swift
+++ b/ios/Igatha/Services/NotificationManager.swift
@@ -1,0 +1,129 @@
+//
+//  NotificationManager.swift
+//  Igatha
+//
+//  Created by Nizar Mahmoud on 22/04/2025.
+//
+
+import Foundation
+import UserNotifications
+import SwiftUI
+
+class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
+    static let shared = NotificationManager()
+
+    // setup is called when the app is launched
+    public func setup() {
+        // Request authorization and schedule notification using Task
+        Task {
+            let granted = await requestAuthorization()
+            guard granted else { return }
+
+            // Schedule feedback request notification when permission is granted
+            await scheduleFeedbackRequestNotification()
+        }
+    }
+
+    private override init() {
+        super.init()
+
+        // Set the delegate for the notification center
+        UNUserNotificationCenter.current().delegate = self
+    }
+
+    // requestAuthorization requests notification permission
+    private func requestAuthorization() async -> Bool {
+        return (try? await UNUserNotificationCenter.current().requestAuthorization(
+            options: [.alert, .sound, .badge]
+        )) ?? false
+    }
+
+    // scheduleFeedbackRequestNotification schedules the feedback request notification
+    private func scheduleFeedbackRequestNotification() async {
+        // Ignore if we have already scheduled the feedback request notification
+        if UserDefaults.standard.object(
+            forKey: Constants.Notifications.Feedback.TimestampKey
+        ) != nil {
+            return
+        }
+
+        let timestamp = Date()
+
+        NSLog("Scheduling feedback request notification at \(timestamp)")
+
+        // Store the timestamp when the notification was scheduled
+        UserDefaults.standard.set(
+            timestamp,
+            forKey: Constants.Notifications.Feedback.TimestampKey
+        )
+
+        // Create the notification content
+        let content = UNMutableNotificationContent()
+        content.title = "Tell us why you use Igatha"
+        content.body = "Help us improve it for you and others"
+        content.sound = .default
+        content.userInfo = [
+            Constants.DeepLink.Key: Constants.Notifications.Feedback.Link.Value
+        ]
+
+        // Schedule the notification for the future
+        let trigger = UNTimeIntervalNotificationTrigger(
+            timeInterval: Constants.Notifications.Feedback.TriggerDelay,
+            repeats: false
+        )
+
+        // Create the notification request
+        let request = UNNotificationRequest(
+            identifier: Constants.Notifications.Feedback.Id,
+            content: content,
+            trigger: trigger
+        )
+
+        // Add the request to the notification center with async/await
+        do {
+            try await UNUserNotificationCenter.current().add(request)
+        } catch {
+            NSLog("Error scheduling feedback request notification: \(error)")
+        }
+    }
+
+    // userNotificationCenter handles the notification response
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        // Get the identifier of the notification
+        let id = response.notification.request.identifier
+
+        // Handle the feedback request notification
+        if id == Constants.Notifications.Feedback.Id {
+            if
+                let deepLink = response.notification.request.content.userInfo[Constants.DeepLink.Key] as? String,
+                deepLink == Constants.Notifications.Feedback.Link.Value
+            {
+                // Post notification on the main thread
+                Task {
+                    await MainActor.run {
+                        NotificationCenter.default.post(
+                            name: NSNotification.Name(Constants.Notifications.Feedback.Link.Name),
+                            object: nil
+                        )
+                    }
+                }
+            }
+        }
+
+        completionHandler()
+    }
+
+    // userNotificationCenter handles the notification presentation
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        // Show the notification even if the app is in foreground
+        completionHandler([.banner, .sound])
+    }
+}

--- a/ios/Igatha/Views/ContentView.swift
+++ b/ios/Igatha/Views/ContentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var viewModel = ContentViewModel()
+    @StateObject private var deepLinkHandler = DeepLinkHandler.shared
 
     var body: some View {
         NavigationView {
@@ -60,7 +61,8 @@ struct ContentView: View {
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarItems(
                 trailing: NavigationLink(
-                    destination: SettingsView()
+                    destination: SettingsView(),
+                    isActive: $deepLinkHandler.showSettings
                 ) {
                     Image(systemName: "gearshape")
                         .imageScale(.large)

--- a/ios/Igatha/Views/SettingsView.swift
+++ b/ios/Igatha/Views/SettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()
-    
+
     var body: some View {
         Form {
             // Background services.
@@ -17,7 +17,7 @@ struct SettingsView: View {
                 // Disaster detection.
                 Toggle(isOn: $viewModel.disasterDetectionEnabled) {
                     Text("Disaster Detection")
-                    
+
                     Text("Detects disasters and sends SOS when the app is not in use. This requires location permission. This may increase battery consumption.")
                         .font(.caption)
                         .foregroundColor(.gray)
@@ -29,7 +29,7 @@ struct SettingsView: View {
                 Text("Services might require additional permissions.")
                     .padding(.vertical, 4)
             }
-            
+
             // Feedback.
             Section {
                 FeedbackButtonView()


### PR DESCRIPTION
Before:
1. If user didn't open Settings, they wouldn't know about user feedback

After:
1. We send users a notification after 3 days to fill the user feedback form

Test:
1. Modify `TriggerDelay` to 10 seconds
2. Uninstall the app
3. Open app the first time, and close it quickly
4. Some seconds later, you'll get a notification
5. Click it and you should go to SettingsView
6. Thne, open the app again and wait a minute or two
7. You should not get an new notification