### PR TITLE
android: Fix disaster-detection-related bugs

### DIFF
--- a/android/app/src/main/java/com/nizarmah/igatha/MainActivity.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/MainActivity.kt
@@ -21,7 +21,11 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            IgathaTheme {
+            IgathaTheme(
+                // Disable dynamic wallpaper-based theming
+                // so our static red primary is used instead
+                dynamicColor = false
+            ) {
                 MainScreen()
             }
         }

--- a/android/app/src/main/java/com/nizarmah/igatha/MainActivity.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.nizarmah.igatha.ui.component.PermissionHandler
 import com.nizarmah.igatha.ui.screen.ContentScreen
 import com.nizarmah.igatha.ui.theme.IgathaTheme
+import com.nizarmah.igatha.util.PermissionsManager
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,6 +25,11 @@ class MainActivity : ComponentActivity() {
                 MainScreen()
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        PermissionsManager.refreshPermissions(this)
     }
 }
 

--- a/android/app/src/main/java/com/nizarmah/igatha/service/DisasterDetectionService.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/service/DisasterDetectionService.kt
@@ -21,7 +21,12 @@ class DisasterDetectionService : Service() {
 
         // Initialize inside onCreate because context is not available earlier
         emergencyManager = EmergencyManager.getInstance(applicationContext)
-        emergencyManager.startDetector()
+        val started = emergencyManager.startDetector()
+
+        // If the detector did not start, stop the service
+        if (!started) {
+            stopSelf()
+        }
 
         // Start the service in the foreground with a low-priority notification
         val notification = createNotification()

--- a/android/app/src/main/java/com/nizarmah/igatha/service/EmergencyManager.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/service/EmergencyManager.kt
@@ -79,10 +79,11 @@ class EmergencyManager private constructor(context: Context) {
         sirenPlayer.stopSiren()
     }
 
-    fun startDetector() {
-        if (!isDetectorAvailable.value || isDetectorActive.value) return
+    fun startDetector(): Boolean {
+        if (!isDetectorAvailable.value || isDetectorActive.value) return false
 
         disasterDetector.startDetection()
+        return true
     }
 
     fun stopDetector() {

--- a/android/app/src/main/java/com/nizarmah/igatha/ui/screen/SettingsScreen.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/ui/screen/SettingsScreen.kt
@@ -18,9 +18,11 @@ fun SettingsScreen(
     val context = LocalContext.current.applicationContext as Application
     val viewModel: SettingsViewModel = viewModel(factory = SettingsViewModelFactory(context))
     val disasterDetectionEnabled by viewModel.disasterDetectionEnabled.collectAsState()
+    val isDisasterDetectionAvailable by viewModel.isDisasterDetectionAvailable.collectAsState()
 
     SettingsView(
         disasterDetectionEnabled = disasterDetectionEnabled,
+        isDisasterDetectionAvailable = isDisasterDetectionAvailable,
         onDisasterDetectionEnabledChanged = { enabled ->
             viewModel.setDisasterDetectionEnabled(enabled)
         },

--- a/android/app/src/main/java/com/nizarmah/igatha/ui/view/SettingsView.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/ui/view/SettingsView.kt
@@ -19,6 +19,7 @@ import com.nizarmah.igatha.ui.theme.IgathaTheme
 @Composable
 fun SettingsView(
     disasterDetectionEnabled: Boolean,
+    isDisasterDetectionAvailable: Boolean,
     onDisasterDetectionEnabledChanged: (Boolean) -> Unit,
     onBackClick: () -> Unit,
     onFeedbackClick: () -> Unit = {}
@@ -74,7 +75,8 @@ fun SettingsView(
 
                             Switch(
                                 checked = disasterDetectionEnabled,
-                                onCheckedChange = onDisasterDetectionEnabledChanged
+                                onCheckedChange = onDisasterDetectionEnabledChanged,
+                                enabled = isDisasterDetectionAvailable
                             )
                         }
                     }
@@ -103,6 +105,7 @@ fun SettingsViewPreview() {
     IgathaTheme {
         SettingsView(
             disasterDetectionEnabled = true,
+            isDisasterDetectionAvailable = true,
             onDisasterDetectionEnabledChanged = {},
             onBackClick = {}
         )

--- a/android/app/src/main/java/com/nizarmah/igatha/util/PermissionsHelper.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/util/PermissionsHelper.kt
@@ -86,17 +86,15 @@ object PermissionsHelper {
             )
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            permissions += arrayOf(
-                Manifest.permission.POST_NOTIFICATIONS
-            )
-        }
-
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             permissions += arrayOf(
                 Manifest.permission.FOREGROUND_SERVICE_HEALTH
             )
         }
+
+        // Foreground services need a notification
+        // So, check notification permissions as well
+        permissions += getNotificationsPermissions()
 
         return permissions
     }

--- a/android/app/src/main/java/com/nizarmah/igatha/viewmodel/ContentViewModel.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/viewmodel/ContentViewModel.kt
@@ -49,7 +49,7 @@ class ContentViewModel(app: Application) : AndroidViewModel(app) {
     init {
         // Observe the disaster detection availability
         viewModelScope.launch {
-            emergencyManager.isDetectorAvailable.collect { available ->
+            emergencyManager.isDetectorEnabled.collect { available ->
                 if (available) {
                     startDisasterDetectionService()
                 } else {

--- a/android/app/src/main/java/com/nizarmah/igatha/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/nizarmah/igatha/viewmodel/SettingsViewModel.kt
@@ -4,9 +4,11 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import com.nizarmah.igatha.util.SettingsManager
 import kotlinx.coroutines.flow.StateFlow
+import com.nizarmah.igatha.service.EmergencyManager
 
 class SettingsViewModel(app: Application) : AndroidViewModel(app) {
     val disasterDetectionEnabled: StateFlow<Boolean> = SettingsManager.disasterDetectionEnabled
+    val isDisasterDetectionAvailable: StateFlow<Boolean> = EmergencyManager.getInstance(getApplication()).isDetectorAvailable
 
     fun setDisasterDetectionEnabled(enabled: Boolean) {
         SettingsManager.setDisasterDetectionEnabled(enabled)


### PR DESCRIPTION
Resolves #36 

Before:
1. Permissions did not refresh on resume
2. Theme primary color on new SDKs used background
3. Service would run even if disaster detection was unavailable
4. It was possible to toggle disaster detection even when unavailable

After:
1. Permissions refresh on resume
2. Theme primary color is static
3. Service doesn't run if disaster detection is unavailable
4. Disaster detection switch is diabled when unavailable

Test:
1. Uninstall the app
2. Run the app with IDE
3. Do not allow permissions
4. Ensure the "SOS" button is red
5. Open the Settings inside the app
6. Ensure the switch is disabled
7. Go to phone Settings, and enable permissions, then switch back to app
8. Ensure the switch is enabled
9. Testing is good enough at this point